### PR TITLE
Ajout de la prise en charge du mode nuit et du retour sonore sur le délai d'entrée

### DIFF
--- a/sync-clavier.yaml
+++ b/sync-clavier.yaml
@@ -64,6 +64,12 @@ action:
                     "mode": "disarm"
                   }
                 }
+                {% elif etat == 'pending' %}
+                {
+                  "arm_mode": {
+                    "mode": "entry_delay"
+                  }
+                }
                 {% elif etat == 'arming' %}
                   {% if trigger.to_state.attributes.next_state == 'armed_home' %}
                   {

--- a/sync-clavier.yaml
+++ b/sync-clavier.yaml
@@ -58,6 +58,12 @@ action:
                     "mode": "arm_day_zones"
                   }
                 }
+                {% elif etat == 'armed_night' %}
+                {
+                  "arm_mode": {
+                    "mode": "arm_night_zones"
+                  }
+                }
                 {% elif etat == 'disarmed' %}
                 {
                   "arm_mode": {
@@ -121,6 +127,15 @@ action:
                             value_template: "{{ trigger.payload_json.action == 'arm_day_zones' }}"
                         sequence:
                           - service: alarm_control_panel.alarm_arm_home
+                            target:
+                              entity_id: !input "panneau_alarme"
+                            data:
+                              code: "{{ trigger.payload_json.action_code }}"
+                      - conditions:
+                          - condition: template
+                            value_template: "{{ trigger.payload_json.action == 'arm_night_zones' }}"
+                        sequence:
+                          - service: alarm_control_panel.alarm_arm_night
                             target:
                               entity_id: !input "panneau_alarme"
                             data:


### PR DESCRIPTION
Hello,

Tout d'abord merci pour cette Blueprint :) 

Cette PR ajoute deux fonctionnalités importantes à la blueprint de synchronisation clavier ↔️ alarme :

✅ Prise en charge du mode nuit (armed_night)
	•	Synchronisation bidirectionnelle du mode armed_night via arm_night_zones.
	•	Le clavier peut désormais activer ce mode avec un code PIN valide.
	•	L’état du panneau armed_night est transmis au clavier en retour.

✅ Feedback sonore pendant le délai d’entrée
	•	Lorsque l’alarme entre en pending (délai d’entrée), un retour sonore est déclenché.
	•	Ce retour permet à l’utilisateur d’être averti que l’alarme est sur le point de se déclencher.
	•	Le bip s’arrête automatiquement si :
	    •	    l'alarme se déclenche et le délai expire (configurable dans alarmo => "Temps de fonctionnement avant réarmement"),
	    •	    l’utilisateur désarme l’alarme.