### PR TITLE
Vérification que action_transaction ne soit pas null

### DIFF
--- a/sync-clavier.yaml
+++ b/sync-clavier.yaml
@@ -100,6 +100,7 @@ action:
                   - condition: template
                     value_template: >
                       {{ trigger.payload_json.action_transaction is defined and
+                         trigger.payload_json.action_transaction is not none and
                          trigger.payload_json.action_code in codes_pins_valides }}
                 sequence:
                   - service: mqtt.publish
@@ -153,6 +154,7 @@ action:
                   - condition: template
                     value_template: >
                       {{ trigger.payload_json.action_transaction is defined and
+                         trigger.payload_json.action_transaction is not none and
                          trigger.payload_json.action_code not in codes_pins_valides }}
                 sequence:
                   - service: mqtt.publish


### PR DESCRIPTION
Bonjour,

Merci pour ce blueprint.

Lorsque j’ai voulu utiliser celui ci sur mon installation, le fonctionnement n’était pas du tout celui attendu, et le clavier se mettait à envoyer des messages en boucle jusqu’à atteindre le nombre maximum le lancement parallèles.

Après une bonne après midi de debug, j’ai trouvé la source : l’attribut last_seen est activé dans mon zigbee2mqtt (pour la détection d’un capteur qui sortirait silencieusement du réseau).

Hors quand cette fonctionnalité est activée, quand un message est envoyé au device, celui ci renvoi un message pour actualiser son last_seen.

Dans le cas du clavier, le message indique un action_transaction à null (puisque pas d’action), mais le check is defined en yaml vérifie si la variable est définie, pas son contenu, et donc null est ici défini. Le blueprint fait alors le traitement, avec un code invalide, et renvoi un message au clavier en mode "invalid_code". Clavier qui répond pour mettre à jour le last_seen... et ainsi de suite rendant tout usage impossible car cela perturbe même la saisie des codes.

Je propose donc cette modification qui vérifie également que action_transaction n’est pas null quand il est défini, ce qui évite cette boucle sans fin.